### PR TITLE
Fixed Parallel Stream Combiner, added tests for it

### DIFF
--- a/src/main/java/edu/iust/advancejava/streams/problems/CollectionProblems.java
+++ b/src/main/java/edu/iust/advancejava/streams/problems/CollectionProblems.java
@@ -37,7 +37,7 @@ public class CollectionProblems {
                 },
                 (xs, ys) -> {
                     xs.forEach((key, value) -> ys.merge(key, value, (xValue, yValue) -> xValue + yValue));
-                    return xs;
+                    return ys;
                 });
     }
 

--- a/src/test/java/edu/iust/advancejava/streams/problems/CollectionProblemsTest.java
+++ b/src/test/java/edu/iust/advancejava/streams/problems/CollectionProblemsTest.java
@@ -54,6 +54,67 @@ public class CollectionProblemsTest {
         expected.put(5, 1);
         expected.put(6, 1);
         assertEquals(expected, stream.collect(frequencies()));
+
+
+        // count the frequency of characters in a string
+        String message = "Java 8 ExAmpLe to execuTe StreaMs in pArallel";
+
+        Map<Character, Integer> expectedCharFrequency= new HashMap<>();
+        expectedCharFrequency.put('j', 1);
+        expectedCharFrequency.put('a', 6);
+        expectedCharFrequency.put('v', 1);
+        expectedCharFrequency.put('8', 1);
+        expectedCharFrequency.put('e', 7);
+        expectedCharFrequency.put('x', 2);
+        expectedCharFrequency.put('m', 2);
+        expectedCharFrequency.put('p', 2);
+        expectedCharFrequency.put('l', 4);
+        expectedCharFrequency.put('t', 3);
+        expectedCharFrequency.put('o', 1);
+        expectedCharFrequency.put('c', 1);
+        expectedCharFrequency.put('u', 1);
+        expectedCharFrequency.put('s', 2);
+        expectedCharFrequency.put('r', 2);
+        expectedCharFrequency.put('i', 1);
+        expectedCharFrequency.put('n', 1);
+        expectedCharFrequency.put(' ', 7);
+
+        // First thing first, convert string into stream of characters
+        // use .chars() to get an instance of IntStream(integer representation of the characters) from the input String.
+        // and then convert it to Stream char via .mapToObj()
+
+        Stream<Character> characterStream = message.toLowerCase().chars().mapToObj(c-> (char) c).parallel();
+
+        assertEquals(
+                expectedCharFrequency,
+                characterStream.collect(frequencies()));
+
+        assertTrue(characterStream.isParallel());
+
+
+
+        Stream<String> dayWiseWeatherReportStream = Stream.of(
+                "Sunny", "Rainy", "Cloudy", "Sunny", "Rainy", "Sunny", "Sunny", "Cloudy", "Rainy", "Sunny",
+                "Sunny", "Rainy", "Cloudy", "Sunny", "Rainy", "Cloudy", "Rainy", "Sunny", "Sunny", "Rainy",
+                "Sunny", "Sunny", "Rainy", "Sunny", "Sunny", "Sunny", "Sunny", "Sunny", "Windy", "Windy",
+                "Rainy").parallel();
+
+        Map<String, Integer> expectedMonthlyFrequencyReport = new HashMap<>();
+        expectedMonthlyFrequencyReport.put("Sunny", 16);
+        expectedMonthlyFrequencyReport.put("Rainy", 9);
+        expectedMonthlyFrequencyReport.put("Cloudy", 4);
+        expectedMonthlyFrequencyReport.put("Windy", 2);
+
+        assertEquals(
+                expectedMonthlyFrequencyReport,
+                dayWiseWeatherReportStream.collect(frequencies())
+        );
+
+        assertTrue(dayWiseWeatherReportStream.isParallel());
+
+        // stream in parallel mode can be converted back to the sequential mode by using the sequential() method
+        assertFalse(dayWiseWeatherReportStream.sequential().isParallel());
+   
     }
 
 }


### PR DESCRIPTION
Ma'am as we are merging all the values from xStream to -> yStream, the returned stream from the combiner method should be yStream instead of xStream.
Also, I have added a few test cases there, although I have tried my level best to follow industry standards still variable names can be weird. If they are, please change them